### PR TITLE
Including MLAT targets on tar1090

### DIFF
--- a/useful-extras/improved-visualisation-with-tar1090.md
+++ b/useful-extras/improved-visualisation-with-tar1090.md
@@ -64,8 +64,10 @@ Remember to change `docker.host.ip.addr` to the IP address of your docker host.
 ## Displaying MLAT aircraft in tar1090
 
 Add the following line to the environment section of the `tar1090` section of `docker-compose.yml`:
+
 ```yaml
       - MLATHOST=adsbx
 ```
-if using the `adsbx` image, or `MLATHOST=piaware` if using the `piaware` image.
+
+The above assumes you wish to display MLAT from the `adsbx` image. You could use `MLATHOST=piaware` if you wish to use the `piaware` image.
 

--- a/useful-extras/improved-visualisation-with-tar1090.md
+++ b/useful-extras/improved-visualisation-with-tar1090.md
@@ -61,5 +61,11 @@ You should also be able to point your web browser at:
 
 Remember to change `docker.host.ip.addr` to the IP address of your docker host.
 
+## Displaying MLAT aircraft in tar1090
 
+Add the following line to the environment section of the `tar1090` section of `docker-compose.yml`:
+```yaml
+      - MLATHOST=adsbx
+```
+if using the `adsbx` image, or `MLATHOST=piaware` if using the `piaware` image.
 


### PR DESCRIPTION
Adding the environment line from https://hub.docker.com/r/mikenye/tar1090 to enable MLAT display to these instructions.