### PR TITLE
update Radarbox docs with UAT steps

### DIFF
--- a/feeder-containers/feeding-radarbox.md
+++ b/feeder-containers/feeding-radarbox.md
@@ -189,6 +189,12 @@ Append the following lines to the end of the file \(inside the `services:` secti
       - /var/log
 ```
 
+If you are in the USA and are also running the `dump978` container with a second SDR, add the following additional lines to the `environment:` section:
+
+```yaml
+      - UAT_RECEIVER_HOST=dump978
+```
+
 To explain what's going on in this addition:
 
 * We're creating a container called `rbfeeder`, from the image `mikenye/rbfeeder:latest`.
@@ -199,6 +205,8 @@ To explain what's going on in this addition:
   * `ALT` will use the `FEEDER_ALT_M` variable from your `.env` file.
   * `TZ` will use the `FEEDER_TZ` variable from your `.env` file.
   * `SHARING_KEY` will use the `RADARBOX_SHARING_KEY` variable from your `.env` file.
+* For people running `dump978`:
+  * `UAT_RECEIVER_HOST=dump978` specifies the host to pull UAT data from; in this instance our `dump978` container.
 * We're using `tmpfs` for volumes that have regular I/O. Any files stored in a `tmpfs` mount are temporarily stored outside the container's writable layer. This helps to reduce:
   * The size of the container, by not writing changes to the underlying container; and
   * SD Card or SSD wear

--- a/feeder-containers/feeding-radarbox.md
+++ b/feeder-containers/feeding-radarbox.md
@@ -30,7 +30,7 @@ You'll need a _sharing key_. To get one, you can temporarily run the container, 
 Inside your application directory \(`/opt/adsb`\), run the following commands:
 
 ```bash
-docker pull mikenye/piaware:latest
+docker pull mikenye/radarbox:latest
 source ./.env
 timeout 60 docker run \
     --rm \

--- a/foundations/deploy-dump978-usa-only.md
+++ b/foundations/deploy-dump978-usa-only.md
@@ -123,8 +123,9 @@ You should also be able to point your web browser at `http://docker.host.ip.addr
 The majority of feeders will happily accept a combined 1090MHz & 978MHz feed coming from `readsb`, so there should be nothing further to do.
 
 The current exceptions are:
-*  `piaware` - FlightAware has separate feeder binaries for 1090MHz and 978MHz. 
-*  `radarbox` - Radarbox needs some additonal paramters to support both 1090MHz and 978MHz. 
+
+*  `piaware` - FlightAware has separate feeder binaries for 1090MHz and 978MHz.
+*  `radarbox` - Radarbox needs some additional parameters to support both 1090MHz and 978MHz.
 
 The additional configuration directives are discussed on each container's page.
 

--- a/foundations/deploy-dump978-usa-only.md
+++ b/foundations/deploy-dump978-usa-only.md
@@ -124,8 +124,8 @@ The majority of feeders will happily accept a combined 1090MHz & 978MHz feed com
 
 The current exceptions are:
 
-*  `piaware` - FlightAware has separate feeder binaries for 1090MHz and 978MHz.
-*  `radarbox` - Radarbox needs some additional parameters to support both 1090MHz and 978MHz.
+* `piaware` - FlightAware has separate feeder binaries for 1090MHz and 978MHz.
+* `radarbox` - Radarbox needs some additional parameters to support both 1090MHz and 978MHz.
 
 The additional configuration directives are discussed on each container's page.
 

--- a/foundations/deploy-dump978-usa-only.md
+++ b/foundations/deploy-dump978-usa-only.md
@@ -122,5 +122,9 @@ You should also be able to point your web browser at `http://docker.host.ip.addr
 
 The majority of feeders will happily accept a combined 1090MHz & 978MHz feed coming from `readsb`, so there should be nothing further to do.
 
-The current exception is the `piaware` container, as FlightAware have separate feeder binaries for 1090MHz and 978MHz. The additional configuration directives are discussed on that container's page.
+The current exceptions are:
+*  `piaware` - FlightAware has separate feeder binaries for 1090MHz and 978MHz. 
+*  `radarbox` - Radarbox needs some additonal paramters to support both 1090MHz and 978MHz. 
+
+The additional configuration directives are discussed on each container's page.
 


### PR DESCRIPTION
My radarbox setup required additional steps beyond what was documented to support UAT.  After making these changes, UAT stats are showing up on the dashboard.

Much of this modeled after the existing UAT steps in the [Feeding Flightaware](https://mikenye.gitbook.io/ads-b/feeder-containers/feeding-flightaware-piaware) page.  Trying to maintain a consistent voice for the docs.

The `UAT_RECEIVER_HOST` value was discovered in the [docker container build scripts](https://github.com/mikenye/docker-radarbox/blob/master/rootfs/etc/cont-init.d/01-rbfeeder#L80-L87)


