### PR TITLE
fixed typo

### DIFF
--- a/foundations/deploy-dump978-usa-only.md
+++ b/foundations/deploy-dump978-usa-only.md
@@ -1,6 +1,6 @@
 ---
 description: >-
-  The "dump978" container is receives 978MHz UAT signals from your SDR, and
+  The "dump978" container receives 978MHz UAT signals from your SDR, and
   demodulates ADS-B UAT messages, making them available for all other
   containers.
 ---


### PR DESCRIPTION
"The dump978 container is receives...." Deleted "is".