### PR TITLE
KerberosSDR is now 404

### DIFF
--- a/intro/equipment-needed.md
+++ b/intro/equipment-needed.md
@@ -4,7 +4,7 @@ To get started, you'll need:
 
 ## **A SDR that can receive 1090MHz**
 
-I started with a [FlightAware Pro Stick Plus](https://www.amazon.com/dp/B07J2RJQ9Z/ref=cm_sw_em_r_mt_dp_U_uwltEbJ8ER2KN). However, eventually you may wish to expand into other areas of SDR. I have moved onto a [KerberosSDR](http://kerberossdr.com/), which is four RTL-SDRs in one. This lets me dedicate one SDR to ADS-B reception, and three others for things like [AirBand](https://en.wikipedia.org/wiki/Airband), [ACARS](https://app.airframes.io), etc.
+I started with a [FlightAware Pro Stick Plus](https://www.amazon.com/dp/B07J2RJQ9Z/ref=cm_sw_em_r_mt_dp_U_uwltEbJ8ER2KN). However, eventually you may wish to expand into other areas of SDR. I have moved onto a [KerberosSDR](https://othernet.is/products/kerberossdr-4x-coherent-rtlsdr), which is four RTL-SDRs in one. This lets me dedicate one SDR to ADS-B reception, and three others for things like [AirBand](https://en.wikipedia.org/wiki/Airband), [ACARS](https://app.airframes.io), etc.
 
 If you're just getting started and don't want to spend a lot of cash, a [$20 USB DVB-T RTL2832U dongle](https://www.aliexpress.com/item/32259584047.html) will do the job.
 


### PR DESCRIPTION
It appears KerberosSDR was picked up by Othernet. The site originally linked is now gone.