### PR TITLE
second half of USB parameter missing

### DIFF
--- a/foundations/deploy-dump978-usa-only.md
+++ b/foundations/deploy-dump978-usa-only.md
@@ -26,7 +26,7 @@ Append the following lines to the end of the file \(inside the `services:` secti
     container_name: dump978
     restart: always
     devices:
-      - /dev/bus/usb
+      - /dev/bus/usb:/dev/bus/usb
     environment:
       - TZ=${FEEDER_TZ}
       - DUMP978_RTLSDR_DEVICE=978


### PR DESCRIPTION
The USB pass-thru parameter was missing half.