### PR TITLE
network_mode: host to compose

### DIFF
--- a/useful-extras/managing-a-remote-station.md
+++ b/useful-extras/managing-a-remote-station.md
@@ -31,6 +31,7 @@ Open the `docker-compose.yml` file that was created when deploying `readsb`. App
     restart: always
     devices:
       - /dev/net/tun
+    network_mode: host
     cap_add:
       - NET_ADMIN
       - SYS_ADMIN


### PR DESCRIPTION
Added ``    network_mode: host`` to the compose to expose ZT to the host system. Thus allowing host system to treat ZT as it would any other network adapter.